### PR TITLE
Improve tests for Maskinporten HTTP client and config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,11 +16,11 @@ type MaskinportenApiConfig struct {
 	Scope    string `koanf:"scope"     validate:"required"`
 }
 
-func GetConfig(operatorContext *operatorcontext.Context) (*Config, error) {
+func GetConfig(operatorContext *operatorcontext.Context, configFilePath string) (*Config, error) {
 	var cfg *Config
 	var err error
 	if operatorContext.IsLocal() {
-		cfg, err = loadFromKoanf(operatorContext)
+		cfg, err = loadFromKoanf(operatorContext, configFilePath)
 	} else {
 		cfg, err = loadFromAzureKeyVault()
 	}
@@ -38,4 +38,12 @@ func GetConfig(operatorContext *operatorcontext.Context) (*Config, error) {
 	// k.Print() // Uncomment to print the config, only for debug, there be secrets
 
 	return cfg, nil
+}
+
+func GetConfigOrDie(operatorContext *operatorcontext.Context, configFilePath string) *Config {
+	cfg, err := GetConfig(operatorContext, configFilePath)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	operatorcontext "github.com/altinn/altinn-k8s-operator/internal/operator_context"
+	"github.com/go-playground/validator/v10"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig_Missing_Values_Fail(t *testing.T) {
+	RegisterTestingT(t)
+
+	file, err := os.CreateTemp(os.TempDir(), "*.env")
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		err := file.Close()
+		Expect(err).NotTo(HaveOccurred())
+	}()
+	defer func() {
+		err := os.Remove(file.Name())
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	_, err = file.WriteString("maskinporten_api.url=https://example.com")
+	Expect(err).NotTo(HaveOccurred())
+
+	operatorContext := operatorcontext.DiscoverOrDie()
+	cfg, err := GetConfig(operatorContext, file.Name())
+	Expect(cfg).To(BeNil())
+	Expect(err).To(HaveOccurred())
+	_, ok := err.(validator.ValidationErrors)
+	errType := reflect.TypeOf(err)
+	Expect(errType.String()).To(Equal("validator.ValidationErrors"))
+	Expect(ok).To(BeTrue())
+}
+
+func TestConfig_TestEnv_Loads_Ok(t *testing.T) {
+	RegisterTestingT(t)
+
+	operatorContext := operatorcontext.DiscoverOrDie()
+	cfg, err := GetConfig(operatorContext, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+	Expect(cfg.MaskinportenApi.ClientId).To(Equal("64d8055d-bf0c-4ee2-979e-d2bbe996a9f5"))
+	Expect(cfg.MaskinportenApi.Url).To(Equal("https://maskinporten.dev"))
+	Expect(cfg.MaskinportenApi.Jwk).NotTo(BeNil())
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestConfig_Missing_Values_Fail(t *testing.T) {
+func TestConfigMissingValuesFail(t *testing.T) {
 	RegisterTestingT(t)
 
 	file, err := os.CreateTemp(os.TempDir(), "*.env")
@@ -37,7 +37,7 @@ func TestConfig_Missing_Values_Fail(t *testing.T) {
 	Expect(ok).To(BeTrue())
 }
 
-func TestConfig_TestEnv_Loads_Ok(t *testing.T) {
+func TestConfigTestEnvLoadsOk(t *testing.T) {
 	RegisterTestingT(t)
 
 	operatorContext := operatorcontext.DiscoverOrDie()

--- a/internal/config/koanf.go
+++ b/internal/config/koanf.go
@@ -16,10 +16,13 @@ var (
 	parser = dotenv.ParserEnv("", ".", func(s string) string { return s })
 )
 
-func loadFromKoanf(operatorContext *operatorcontext.Context) (*Config, error) {
+func loadFromKoanf(operatorContext *operatorcontext.Context, configFilePath string) (*Config, error) {
 	tryFindProjectRoot()
 
-	filePath := "local.env"
+	if configFilePath == "" {
+		configFilePath = "local.env"
+	}
+
 	if !operatorContext.IsLocal() {
 		return nil, fmt.Errorf("loading config from koanf is only supported for local environment")
 	}
@@ -28,26 +31,26 @@ func loadFromKoanf(operatorContext *operatorcontext.Context) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		if path.IsAbs(filePath) {
-			return nil, fmt.Errorf("env file does not exist: '%s'", filePath)
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		if path.IsAbs(configFilePath) {
+			return nil, fmt.Errorf("env file does not exist: '%s'", configFilePath)
 		} else {
-			return nil, fmt.Errorf("env file does not exist in '%s': '%s'", currentDir, filePath)
+			return nil, fmt.Errorf("env file does not exist in '%s': '%s'", currentDir, configFilePath)
 		}
 	}
 
-	if !path.IsAbs(filePath) {
-		filePath = path.Join(currentDir, filePath)
+	if !path.IsAbs(configFilePath) {
+		configFilePath = path.Join(currentDir, configFilePath)
 	}
 
-	if err := k.Load(file.Provider(filePath), parser); err != nil {
-		return nil, fmt.Errorf("error loading config '%s': %w", filePath, err)
+	if err := k.Load(file.Provider(configFilePath), parser); err != nil {
+		return nil, fmt.Errorf("error loading config '%s': %w", configFilePath, err)
 	}
 
 	var cfg Config
 
 	if err := k.Unmarshal("", &cfg); err != nil {
-		return nil, fmt.Errorf("error unmarshalling config '%s': %w", filePath, err)
+		return nil, fmt.Errorf("error unmarshalling config '%s': %w", configFilePath, err)
 	}
 
 	return &cfg, nil

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -22,7 +22,7 @@ func NewRuntime() (rt.Runtime, error) {
 		return nil, err
 	}
 
-	cfg, err := config.GetConfig(operatorContext)
+	cfg, err := config.GetConfig(operatorContext, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/maskinporten/http_api_client_test.go
+++ b/internal/maskinporten/http_api_client_test.go
@@ -82,6 +82,19 @@ func getMaskinportenApiWellKnownFixture(g *gomega.WithT, statusCode int) (*httpt
 	)
 }
 
+func TestFixtureIsNotRemote(t *testing.T) {
+	g := NewWithT(t)
+
+	operatorContext := operatorcontext.DiscoverOrDie()
+	configBefore := config.GetConfigOrDie(operatorContext, "")
+
+	server, configAfter := getMaskinportenApiWellKnownFixture(g, http.StatusOK)
+	defer server.Close()
+
+	g.Expect(configAfter.MaskinportenApi.Url).NotTo(Equal(configBefore.MaskinportenApi.Url))
+	g.Expect(configAfter.MaskinportenApi.Url).To(ContainSubstring("http://127.0.0.1"))
+}
+
 func TestWellKnownConfigOk(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/internal/maskinporten/http_api_client_test.go
+++ b/internal/maskinporten/http_api_client_test.go
@@ -2,29 +2,128 @@ package maskinporten
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/altinn/altinn-k8s-operator/internal/caching"
 	"github.com/altinn/altinn-k8s-operator/internal/config"
 	operatorcontext "github.com/altinn/altinn-k8s-operator/internal/operator_context"
+	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
+	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
-func TestWellKnownConfig(t *testing.T) {
+type testApi struct {
+	path         string
+	statusCode   int
+	responseBody string
+}
+
+func getMaskinportenApiFixture(
+	g *gomega.WithT,
+	generateApis func(cfg *config.Config) (apis []testApi),
+) (*httptest.Server, *config.Config) {
+	operatorContext := operatorcontext.DiscoverOrDie()
+	cfg := config.GetConfigOrDie(operatorContext, "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apis := generateApis(cfg)
+		for _, api := range apis {
+			if api.path != r.URL.Path {
+				continue
+			}
+
+			w.WriteHeader(api.statusCode)
+			if api.responseBody != "" {
+				w.Header().Add("Content-Type", "application/json")
+				_, err := w.Write([]byte(api.responseBody))
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	cfg.MaskinportenApi.Url = server.URL
+	return server, cfg
+}
+
+func okWellKnownHandler(g *gomega.WithT, cfg *config.Config) testApi {
+	tokenEndpoint, err := url.JoinPath(cfg.MaskinportenApi.Url, "/token")
+	g.Expect(err).NotTo(HaveOccurred())
+	jwksEndpoint, err := url.JoinPath(cfg.MaskinportenApi.Url, "/jwk")
+	g.Expect(err).NotTo(HaveOccurred())
+	body := fmt.Sprintf(
+		`{"issuer":"%s","token_endpoint":"%s","jwks_uri":"%s","token_endpoint_auth_methods_supported":["private_key_jwt"],"grant_types_supported":["urn:ietf:params:oauth:grant-type:jwt-bearer"],"token_endpoint_auth_signing_alg_values_supported":["RS256","RS384","RS512"],"authorization_details_types_supported":["urn:altinn:systemuser"]}`,
+		cfg.MaskinportenApi.Url,
+		tokenEndpoint,
+		jwksEndpoint,
+	)
+
+	return testApi{"/.well-known/oauth-authorization-server", http.StatusOK, body}
+}
+
+func getMaskinportenApiWellKnownFixture(g *gomega.WithT, statusCode int) (*httptest.Server, *config.Config) {
+	return getMaskinportenApiFixture(
+		g,
+		func(cfg *config.Config) (apis []testApi) {
+			if statusCode == http.StatusOK {
+				return []testApi{okWellKnownHandler(g, cfg)}
+			} else {
+				return []testApi{{"/.well-known/oauth-authorization-server", statusCode, ""}}
+			}
+		},
+	)
+}
+
+func TestWellKnownConfigOk(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	operatorContext, err := operatorcontext.Discover()
+	server, cfg := getMaskinportenApiWellKnownFixture(g, http.StatusOK)
+	defer server.Close()
+
+	apiClient, err := newApiClient(&cfg.MaskinportenApi, clock)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	cfg, err := config.GetConfig(operatorContext)
+	config, err := apiClient.getWellKnownConfiguration(ctx)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(cfg).NotTo(BeNil())
+	g.Expect(config).NotTo(BeNil())
+	tokenEndpoint, err := url.JoinPath(cfg.MaskinportenApi.Url, "/token")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(config.TokenEndpoint).To(Equal(tokenEndpoint))
+}
+
+func TestWellKnownConfigNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	server, cfg := getMaskinportenApiWellKnownFixture(g, http.StatusNotFound)
+	defer server.Close()
+
+	apiClient, err := newApiClient(&cfg.MaskinportenApi, clock)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	config, err := apiClient.getWellKnownConfiguration(ctx)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(config).To(BeNil())
+}
+
+func TestWellKnownConfigCaches(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	server, cfg := getMaskinportenApiWellKnownFixture(g, http.StatusOK)
+	defer server.Close()
 
 	apiClient, err := newApiClient(&cfg.MaskinportenApi, clock)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -53,12 +152,8 @@ func TestCreateGrant(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	operatorContext, err := operatorcontext.Discover()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	cfg, err := config.GetConfig(operatorContext)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(cfg).NotTo(BeNil())
+	server, cfg := getMaskinportenApiWellKnownFixture(g, http.StatusOK)
+	defer server.Close()
 
 	client, err := newApiClient(&cfg.MaskinportenApi, clock)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -68,60 +163,43 @@ func TestCreateGrant(t *testing.T) {
 	g.Expect(grant).NotTo(BeNil())
 }
 
-// Integration test
-// func TestFetchAccessToken(t *testing.T) {
-// 	g := NewWithT(t)
-// 	ctx := context.Background()
-// 	clock := clockwork.NewFakeClock()
+func getMaskinportenApiAccessTokenFixture(g *gomega.WithT, statusCode int) (*httptest.Server, *config.Config, string) {
+	accessToken := uuid.NewString()
 
-// 	operatorContext, err := operatorcontext.Discover()
-// 	g.Expect(err).NotTo(HaveOccurred())
+	server, cfg := getMaskinportenApiFixture(
+		g,
+		func(cfg *config.Config) (apis []testApi) {
+			var body string
+			if statusCode == http.StatusOK {
+				body = fmt.Sprintf(
+					`{"access_token":"%s","token_type":"Bearer","expires_in":3600}`,
+					accessToken,
+				)
+			}
+			return []testApi{
+				okWellKnownHandler(g, cfg),
+				{"/token", statusCode, body},
+			}
+		},
+	)
 
-// 	cfg, err := config.GetConfig(operatorContext)
-// 	g.Expect(err).NotTo(HaveOccurred())
-// 	g.Expect(cfg).NotTo(BeNil())
+	return server, cfg, accessToken
+}
 
-// 	client, err := newApiClient(&cfg.MaskinportenApi, clock)
-// 	g.Expect(err).NotTo(HaveOccurred())
-
-// 	token, err := client.accessTokenFetcher(ctx)
-// 	g.Expect(err).NotTo(HaveOccurred())
-// 	g.Expect(token.AccessToken).NotTo(BeNil())
-// }
-
-func TestFetchAccessTokenWithHTTPTest(t *testing.T) {
+func TestFetchAccessToken(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	// Create a mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(`{"access_token":"mock_access_token","token_type":"Bearer","expires_in":3600}`))
-		g.Expect(err).NotTo(HaveOccurred())
-	}))
+	server, cfg, accessToken := getMaskinportenApiAccessTokenFixture(g, http.StatusOK)
 	defer server.Close()
-
-	operatorContext, err := operatorcontext.Discover()
-	g.Expect(err).NotTo(HaveOccurred())
-
-	cfg, err := config.GetConfig(operatorContext)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(cfg).NotTo(BeNil())
-
-	cfg.MaskinportenApi.Url = server.URL
 
 	client, err := newApiClient(&cfg.MaskinportenApi, clock)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	token, err := client.accessTokenFetcher(ctx)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(token.AccessToken).NotTo(BeNil())
-}
-
-func mockTokenRetriever(ctx context.Context) (*tokenResponse, error) {
-	// Return a mock tokenResponse
-	return &tokenResponse{AccessToken: "mock_access_token"}, nil
+	g.Expect(token.AccessToken).To(Equal(accessToken))
 }
 
 func TestCreateReq(t *testing.T) {
@@ -129,10 +207,14 @@ func TestCreateReq(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
+	accessToken := uuid.NewString()
 	client := &httpApiClient{
 		// Setup mock for accessToken with a custom retriever function.
 		// This Cached[tokenResponse] instance will return the mock token when Get is called.
-		accessToken: caching.NewCachedAtom(time.Minute*5, clock, mockTokenRetriever),
+		accessToken: caching.NewCachedAtom(time.Minute*5, clock, func(ctx context.Context) (*tokenResponse, error) {
+			// Return a mock tokenResponse
+			return &tokenResponse{AccessToken: accessToken}, nil
+		}),
 	}
 
 	var endpoint = "http://example.com/api/endpoint"
@@ -143,5 +225,6 @@ func TestCreateReq(t *testing.T) {
 	g.Expect(req.Method).To(Equal("POST"))
 	g.Expect(req.URL.String()).To(Equal(endpoint))
 	g.Expect(req.Header.Get("Content-Type")).To(Equal("application/x-www-form-urlencoded"))
-	g.Expect(req.Header.Get("Authorization")).To(Equal("Bearer mock_access_token"))
+	expectedHeader := fmt.Sprintf("Bearer %s", accessToken)
+	g.Expect(req.Header.Get("Authorization")).To(Equal(expectedHeader))
 }

--- a/internal/operator_context/operator_context.go
+++ b/internal/operator_context/operator_context.go
@@ -19,3 +19,11 @@ func Discover() (*Context, error) {
 
 	return &Context{Te: te, Env: env}, nil
 }
+
+func DiscoverOrDie() *Context {
+	context, err := Discover()
+	if err != nil {
+		panic(err)
+	}
+	return context
+}


### PR DESCRIPTION
## Description
Improves the testing situation a bit around Maskinporten HTTP client and config

## Related Issue(s)
- https://github.com/Altinn/altinn-k8s-operator/issues/5

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
